### PR TITLE
params.productId fixed error, but why

### DIFF
--- a/src/components/ListItem/ListItem.jsx
+++ b/src/components/ListItem/ListItem.jsx
@@ -14,8 +14,10 @@ const ListItem = (item) => {
                     <h2>{item.tagline}</h2>
                     <p>Created by {item.name}</p>
                     <Link
-                    className='details'
-                    to={`/products/${item.id}`}>Details</Link>
+                        className='details'
+                        to={`/products/${item.id}`}>
+                        Details
+                    </Link>
                 </div>
             </article>
         </>

--- a/src/pages/ProductPage.jsx
+++ b/src/pages/ProductPage.jsx
@@ -25,6 +25,8 @@ const ProductPage = () => {
                     return data
                 })
         }
+    // ?  without `params.productId` in []: 
+    // ? Line 29:8:  React Hook useEffect has a missing dependency: 'params.productId'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
     }, [params.productId])
 
     console.log(state);


### PR DESCRIPTION
_without `params.productId` in []:_ 
Line 29:8:  React Hook useEffect has a missing dependency: 'params.productId'. Either include it or remove the dependency array  react-hooks/exhaustive-deps